### PR TITLE
Archive repo: point to Open Dealer docs hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Archived
+
+This repo is archived. Current docs live in the Open Dealer platform repo:
+- docs/ARCHITECTURE.md
+- docs/ROADMAP.md
+
+---
+
 # Open Dealer - Business Plan & Architecture
 
 ## Overview


### PR DESCRIPTION
This repository is now archived. Current, canonical docs live in the Open Dealer platform repo under docs/.\n- docs/ARCHITECTURE.md\n- docs/ROADMAP.md\n\nPlease merge, then mark the repo Archived in GitHub settings.